### PR TITLE
Cosmos Command pack: change Heat Engine to trigger on any 2+ cost card being played (instead of being exhausted)

### DIFF
--- a/src/main/java/thePackmaster/cards/cosmoscommandpack/HeatEngine.java
+++ b/src/main/java/thePackmaster/cards/cosmoscommandpack/HeatEngine.java
@@ -11,7 +11,7 @@ public class HeatEngine extends AbstractCosmosCard {
     public final static String ID = makeID("HeatEngine");
 
     public HeatEngine() {
-        super(ID, 1, CardType.POWER, CardRarity.UNCOMMON, CardTarget.SELF);
+        super(ID, 2, CardType.POWER, CardRarity.UNCOMMON, CardTarget.SELF);
         magicNumber = baseMagicNumber = 1;
     }
 
@@ -21,6 +21,6 @@ public class HeatEngine extends AbstractCosmosCard {
     }
 
     public void upp() {
-        upgradeBaseCost(0);
+        upgradeBaseCost(1);
     }
 }

--- a/src/main/java/thePackmaster/powers/cosmoscommandpack/HeatEnginePower.java
+++ b/src/main/java/thePackmaster/powers/cosmoscommandpack/HeatEnginePower.java
@@ -1,6 +1,7 @@
 package thePackmaster.powers.cosmoscommandpack;
 
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.utility.UseCardAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
@@ -22,7 +23,7 @@ public class HeatEnginePower extends AbstractPackmasterPower {
     }
 
     @Override
-    public void onExhaust(AbstractCard card) {
+    public void onUseCard(AbstractCard card, UseCardAction action) {
         if (getLogicalCardCost(card) >= 2 || (card instanceof AmplifyCard && getLogicalCardCost(card) + ((AmplifyCard) card).getAmplifyCost() >= 2)) {
             this.flash();
             atb(new ApplyPowerAction(this.owner, this.owner, new StrengthPower(this.owner, this.amount), this.amount));

--- a/src/main/resources/anniv5Resources/localization/eng/cosmoscommandpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/cosmoscommandpack/Cardstrings.json
@@ -21,7 +21,7 @@
   },
   "${ModID}:HeatEngine": {
     "NAME": "Heat Engine",
-    "DESCRIPTION": "Whenever a card with a cost of 2 or greater, including ${ModID}:Amplify, is Exhausted, gain !M! Strength."
+    "DESCRIPTION": "Whenever you play a card with a cost of 2 or greater, including ${ModID}:Amplify, gain !M! Strength."
   },
   "${ModID}:RefractEnergy": {
     "NAME": "Refract Energy",

--- a/src/main/resources/anniv5Resources/localization/eng/cosmoscommandpack/Powerstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/cosmoscommandpack/Powerstrings.json
@@ -2,8 +2,8 @@
   "${ModID}:HeatEnginePower": {
     "NAME": "Heat Engine",
     "DESCRIPTIONS": [
-      "Whenever a card with a cost of #b",
-      " or greater, including #yAmplify, is #yExhausted, gain #b",
+      "Whenever you play a card with a cost of #b",
+      " or greater, including #yAmplify, gain #b",
       " #yStrength."
       ]
   },


### PR DESCRIPTION
This makes the card a real scaling option for decks with a good number of 2+ cost cards (or Snecko Eye), so I increased the cost as well (from 1 to 2).