### PR TITLE
Frost and Eldritch Horror balance adjustments

### DIFF
--- a/src/main/java/thePackmaster/cards/cthulhupack/StarSpawn.java
+++ b/src/main/java/thePackmaster/cards/cthulhupack/StarSpawn.java
@@ -12,7 +12,7 @@ import static thePackmaster.SpireAnniversary5Mod.makeID;
 public class StarSpawn extends AbstractCthulhuCard {
     public final static String ID = makeID("StarSpawn");
 
-    private static final int ATTACK_DMG = 13;
+    private static final int ATTACK_DMG = 10;
     private static final int HEAL = 6;
     private static final int UPGRADE_PLUS_ATTACK_DMG = 3;
     private static final int UPGRADE_HEAL = 3;

--- a/src/main/java/thePackmaster/cards/frostpack/Hailstorm.java
+++ b/src/main/java/thePackmaster/cards/frostpack/Hailstorm.java
@@ -21,8 +21,8 @@ public class Hailstorm extends AbstractFrostCard {
 
     public Hailstorm() {
         super(ID, 3, CardType.ATTACK, CardRarity.RARE, CardTarget.ALL_ENEMY);
-        baseDamage = 2;
-        baseMagicNumber = magicNumber = 5;
+        baseDamage = 3;
+        baseMagicNumber = magicNumber = 4;
         this.showEvokeValue = true;
         this.showEvokeOrbCount = this.magicNumber;
     }

--- a/src/main/java/thePackmaster/powers/cthulhupack/NextTurnGainMadnessPower.java
+++ b/src/main/java/thePackmaster/powers/cthulhupack/NextTurnGainMadnessPower.java
@@ -24,7 +24,7 @@ public class NextTurnGainMadnessPower extends AbstractPackmasterPower implements
 
     public void atStartOfTurn() {
         Wiz.atb(new AddTemporaryHPAction(Wiz.p(), Wiz.p(), amount));
-        Wiz.atb(new GainEnergyAction(3));
+        Wiz.atb(new GainEnergyAction(2));
         Wiz.atb(new ChangeStanceAction(new NightmareStance()));
         removeThisInvisibly();
     }

--- a/src/main/resources/anniv5Resources/localization/eng/cthulhupack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/cthulhupack/Cardstrings.json
@@ -36,7 +36,7 @@
   },
   "${ModID}:RlyehFhtagn": {
     "NAME": "R'lyeh Fhtagn",
-    "DESCRIPTION": "End your turn. NL Next turn, gain !M! Temporary_HP, gain NL [E] [E] [E] , and enter ${ModID}:Nightmare. Exhaust."
+    "DESCRIPTION": "End your turn. NL Next turn, gain !M! Temporary_HP, gain NL [E] [E] , and enter ${ModID}:Nightmare. Exhaust."
   },
   "${ModID}:StarSpawn": {
     "NAME": "Star Spawn",

--- a/src/main/resources/anniv5Resources/localization/zhs/cthulhupack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/zhs/cthulhupack/Cardstrings.json
@@ -36,7 +36,7 @@
   },
   "${ModID}:RlyehFhtagn": {
     "NAME": "弢莜燊暠",
-    "DESCRIPTION": "结束你的回合。 NL 下回合： NL 获得 !M! 层 临时生命 。 NL 获得 [E] [E] [E] 。 NL 进入 ${ModID}:梦魇 。 NL 消耗 。"
+    "DESCRIPTION": "结束你的回合。 NL 下回合： NL 获得 !M! 层 临时生命 。 NL 获得 [E] [E] 。 NL 进入 ${ModID}:梦魇 。 NL 消耗 。"
   },
   "${ModID}:StarSpawn": {
     "NAME": "斗星召唤",


### PR DESCRIPTION
* Frost pack: change Hailstorm to only hit 4 times / channel 4 orbs (from 5/5), increase damage by 1 in exchange
* Eldritch Horror pack: reduce Rlyeh Fhtagn next turn energy gain to 2 (from 3)
* Eldritch Horror pack: reduce Starspawn damage to 10x2 (from 13x2)