### PR TITLE
Spheres pack balance adjustments

### DIFF
--- a/src/main/java/thePackmaster/cards/spherespack/Consolidate.java
+++ b/src/main/java/thePackmaster/cards/spherespack/Consolidate.java
@@ -2,6 +2,7 @@ package thePackmaster.cards.spherespack;
 
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.common.DrawCardAction;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
@@ -12,10 +13,12 @@ public class Consolidate extends AbstractSpheresCard {
     public static final String ID = SpireAnniversary5Mod.makeID("Consolidate");
     private static final int COST = 1;
     private static final int FOCUS = 1;
+    private static final int DRAW = 1;
 
     public Consolidate() {
         super(ID, COST, CardType.SKILL, CardRarity.UNCOMMON, CardTarget.SELF);
         this.magicNumber = this.baseMagicNumber = FOCUS;
+        this.secondMagic = this.baseSecondMagic = DRAW;
         this.isEthereal = true;
     }
 
@@ -34,5 +37,6 @@ public class Consolidate extends AbstractSpheresCard {
             }
         });
         this.addToBot(new ApplyPowerAction(p, p, new FocusPower(p, this.magicNumber)));
+        this.addToBot(new DrawCardAction(this.secondMagic));
     }
 }

--- a/src/main/java/thePackmaster/cards/spherespack/Fluctuate.java
+++ b/src/main/java/thePackmaster/cards/spherespack/Fluctuate.java
@@ -17,9 +17,9 @@ import java.util.Collections;
 public class Fluctuate extends AbstractSpheresCard {
     public static final String ID = SpireAnniversary5Mod.makeID("Fluctuate");
     private static final int COST = 1;
+    private static final int UPGRADE_COST = 0;
     private static final int AMOUNT = 1;
-    private static final int EXTRA_AMOUNT = 1;
-    private static final int UPGRADE_EXTRA_AMOUNT = 1;
+    private static final int EXTRA_AMOUNT = 2;
 
     public Fluctuate() {
         super(ID, COST, CardType.SKILL, CardRarity.UNCOMMON, CardTarget.ALL_ENEMY);
@@ -28,7 +28,7 @@ public class Fluctuate extends AbstractSpheresCard {
 
     @Override
     public void upp() {
-        this.upgradeMagicNumber(UPGRADE_EXTRA_AMOUNT);
+        this.upgradeBaseCost(UPGRADE_COST);
     }
 
     @Override

--- a/src/main/resources/anniv5Resources/localization/eng/spherespack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/spherespack/Cardstrings.json
@@ -26,8 +26,8 @@
   },
   "${ModID}:Consolidate": {
     "NAME": "Consolidate",
-    "DESCRIPTION": "Ethereal. NL Remove your first Orb. NL Gain 1 Focus.",
-    "UPGRADE_DESCRIPTION": "Remove your first Orb. NL Gain 1 Focus."
+    "DESCRIPTION": "Ethereal. NL Remove your first Orb. NL Gain 1 Focus. NL Draw 1 card.",
+    "UPGRADE_DESCRIPTION": "Remove your first Orb. NL Gain 1 Focus. NL Draw 1 card."
   },
   "${ModID}:FrostConversion": {
     "NAME": "Frost Conversion",


### PR DESCRIPTION
* Spheres pack: change Consolidate to draw a card in addition to its other effects
* Spheres pack: change Fluctuate bonus effect to apply 2 weak/vulnerable and change upgrade to reduce cost to 0