### PR TITLE
Cosmos Command/Sentinel/Intrigue buffs

### DIFF
--- a/src/main/java/thePackmaster/cards/cosmoscommandpack/AstralFracture.java
+++ b/src/main/java/thePackmaster/cards/cosmoscommandpack/AstralFracture.java
@@ -18,7 +18,7 @@ public class AstralFracture extends AbstractCosmosCard implements AmplifyCard {
 
     public AstralFracture() {
         super(ID, 0, CardType.SKILL, CardRarity.UNCOMMON, CardTarget.ALL_ENEMY);
-        magicNumber = baseMagicNumber = 4;
+        magicNumber = baseMagicNumber = 5;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {

--- a/src/main/java/thePackmaster/cards/cosmoscommandpack/RopeTrick.java
+++ b/src/main/java/thePackmaster/cards/cosmoscommandpack/RopeTrick.java
@@ -12,7 +12,7 @@ public class RopeTrick extends AbstractCosmosCard {
 
     public RopeTrick() {
         super(ID, 1, CardType.SKILL, CardRarity.COMMON, CardTarget.ENEMY);
-        magicNumber = baseMagicNumber = 4;
+        magicNumber = baseMagicNumber = 5;
         block = baseBlock = 5;
     }
 

--- a/src/main/java/thePackmaster/cards/cosmoscommandpack/Subspace.java
+++ b/src/main/java/thePackmaster/cards/cosmoscommandpack/Subspace.java
@@ -18,7 +18,7 @@ public class Subspace extends AbstractCosmosCard {
 
     public Subspace() {
         super(ID, 0, CardType.SKILL, CardRarity.UNCOMMON, CardTarget.ALL_ENEMY);
-        magicNumber = baseMagicNumber = 1;
+        magicNumber = baseMagicNumber = 2;
         this.exhaust = true;
     }
 

--- a/src/main/java/thePackmaster/cards/intriguepack/Apex.java
+++ b/src/main/java/thePackmaster/cards/intriguepack/Apex.java
@@ -25,6 +25,7 @@ public class Apex extends AbstractIntrigueCard {
     public Apex() {
         super(ID, 2, CardType.SKILL, CardRarity.RARE, CardTarget.SELF);
         magicNumber = baseMagicNumber = 3;
+        selfRetain = true;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {

--- a/src/main/java/thePackmaster/cards/intriguepack/Shakedown.java
+++ b/src/main/java/thePackmaster/cards/intriguepack/Shakedown.java
@@ -14,7 +14,7 @@ import static thePackmaster.SpireAnniversary5Mod.makeID;
 public class Shakedown extends AbstractIntrigueCard {
     public final static String ID = makeID("Shakedown");
 
-    private static final int DAMAGE = 7;
+    private static final int DAMAGE = 8;
     private static final int UPGRADE_PLUS_DMG = 3;
 
     public Shakedown() {

--- a/src/main/java/thePackmaster/cards/sentinelpack/Fume.java
+++ b/src/main/java/thePackmaster/cards/sentinelpack/Fume.java
@@ -1,9 +1,11 @@
 package thePackmaster.cards.sentinelpack;
 
 
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.actions.watcher.ChangeStanceAction;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.powers.watcher.VigorPower;
 import thePackmaster.stances.sentinelpack.Angry;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
@@ -11,13 +13,16 @@ import static thePackmaster.SpireAnniversary5Mod.makeID;
 
 public class Fume extends AbstractSentinelCard {
     public final static String ID = makeID("Fume");
+    private final static int VIGOR = 2;
 
     public Fume() {
         super(ID, 1, CardType.SKILL, CardRarity.COMMON, CardTarget.SELF);
+        this.magicNumber = this.baseMagicNumber = VIGOR;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
         this.addToBot(new ChangeStanceAction(new Angry()));
+        this.addToBot(new ApplyPowerAction(p, p, new VigorPower(p, this.magicNumber)));
     }
 
 

--- a/src/main/java/thePackmaster/cards/sentinelpack/MoodSwing.java
+++ b/src/main/java/thePackmaster/cards/sentinelpack/MoodSwing.java
@@ -19,7 +19,7 @@ public class MoodSwing extends AbstractSentinelCard {
 
     public MoodSwing() {
         super(ID, 1, CardType.SKILL, CardRarity.UNCOMMON, CardTarget.SELF);
-        baseMagicNumber = magicNumber = 2;
+        baseMagicNumber = magicNumber = 3;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {

--- a/src/main/java/thePackmaster/cards/sentinelpack/Relax.java
+++ b/src/main/java/thePackmaster/cards/sentinelpack/Relax.java
@@ -1,6 +1,7 @@
 package thePackmaster.cards.sentinelpack;
 
 
+import com.megacrit.cardcrawl.actions.common.GainBlockAction;
 import com.megacrit.cardcrawl.actions.watcher.ChangeStanceAction;
 import com.megacrit.cardcrawl.cards.blue.Claw;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
@@ -13,13 +14,16 @@ import static thePackmaster.SpireAnniversary5Mod.makeID;
 
 public class Relax extends AbstractSentinelCard {
     public final static String ID = makeID("Relax");
+    private final static int BLOCK = 2;
 
     public Relax() {
         super(ID, 1, CardType.SKILL, CardRarity.COMMON, CardTarget.SELF);
+        this.baseBlock = BLOCK;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
         this.addToBot(new ChangeStanceAction(new CalmStance()));
+        this.addToBot(new GainBlockAction(p, this.block));
     }
 
 

--- a/src/main/java/thePackmaster/cards/sentinelpack/StanceDance.java
+++ b/src/main/java/thePackmaster/cards/sentinelpack/StanceDance.java
@@ -16,7 +16,7 @@ public class StanceDance extends AbstractSentinelCard {
 
     public StanceDance() {
         super(ID, 1, CardType.ATTACK, CardRarity.UNCOMMON, CardTarget.ENEMY);
-        baseDamage = 8;
+        baseDamage = 10;
         exhaust = true;
     }
 

--- a/src/main/resources/anniv5Resources/localization/eng/cosmoscommandpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/cosmoscommandpack/Cardstrings.json
@@ -33,8 +33,7 @@
   },
   "${ModID}:Subspace": {
     "NAME": "Subspace",
-    "DESCRIPTION": "ALL enemies lose HP equal to their ${ModID}:Distortion. NL Exhaust.",
-    "UPGRADE_DESCRIPTION": "ALL enemies lose HP equal to !M! times their ${ModID}:Distortion. NL Exhaust."
+    "DESCRIPTION": "ALL enemies lose HP equal to !M! times their ${ModID}:Distortion. NL Exhaust."
   },
   "${ModID}:SubtleKnife": {
     "NAME": "Subtle Knife",

--- a/src/main/resources/anniv5Resources/localization/eng/intriguepack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/intriguepack/Cardstrings.json
@@ -40,7 +40,7 @@
   },
   "${ModID}:Apex": {
     "NAME": "Apex",
-    "DESCRIPTION": "If all cards in hand are ${ModID}:Precious, ${ModID}:Ascend. ${ModID}:Demote all cards in hand to common."
+    "DESCRIPTION": "Retain. NL If all cards in hand are ${ModID}:Precious, ${ModID}:Ascend. ${ModID}:Demote all cards in hand to common."
   },
   "${ModID}:PowerStruggle": {
     "NAME": "Power Struggle",

--- a/src/main/resources/anniv5Resources/localization/eng/sentinelpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/sentinelpack/Cardstrings.json
@@ -1,8 +1,8 @@
 {
   "${ModID}:Fume": {
     "NAME": "Fume",
-    "DESCRIPTION": "Enter ${ModID}:Angry.",
-    "UPGRADE_DESCRIPTION": "Retain. NL Enter ${ModID}:Angry."
+    "DESCRIPTION": "Enter ${ModID}:Angry. NL Gain !M! Vigor.",
+    "UPGRADE_DESCRIPTION": "Retain. NL Enter ${ModID}:Angry. NL Gain !M! Vigor."
   },
   "${ModID}:Relax": {
     "NAME": "Relax",

--- a/src/main/resources/anniv5Resources/localization/eng/sentinelpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/sentinelpack/Cardstrings.json
@@ -6,8 +6,8 @@
   },
   "${ModID}:Relax": {
     "NAME": "Relax",
-    "DESCRIPTION": "Enter Calm.",
-    "UPGRADE_DESCRIPTION": "Retain. NL Enter Calm."
+    "DESCRIPTION": "Enter Calm. NL Gain !B! Block.",
+    "UPGRADE_DESCRIPTION": "Retain. NL Enter Calm. NL Gain !B! Block."
   },
   "${ModID}:StanceDance": {
     "NAME": "Stance Dance",

--- a/src/main/resources/anniv5Resources/localization/zhs/cosmoscommandpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/zhs/cosmoscommandpack/Cardstrings.json
@@ -33,8 +33,7 @@
   },
   "${ModID}:Subspace": {
     "NAME": "子空间",
-    "DESCRIPTION": "所有敌人失去 ${ModID}:扭曲 层数点生命。 NL 消耗 。",
-    "UPGRADE_DESCRIPTION": "所有敌人失去 ${ModID}:扭曲 层数点生命 !M! 次。 NL 消耗 。"
+    "DESCRIPTION": "所有敌人失去 ${ModID}:扭曲 层数点生命 !M! 次。 NL 消耗 。"
   },
   "${ModID}:SubtleKnife": {
     "NAME": "奥秘匕首",


### PR DESCRIPTION
* Cosmos Command pack: increase Rope Trick distortion by 1
* Cosmos Command pack: increase Astral Fracture distortion by 1
* Cosmos Command pack: increase Subspace HP loss multiplier by 1
* Sentinel pack: increase Stance Dance damage by 2
* Sentinel pack: increase Mood Swing draw and discard by 1
* Sentinel pack: change Relax to also give 2 block
* Sentinel pack: change Fume to also give 2 vigor
* Intrigue pack: increase Shakedown damage by 1
* Intrigue pack: change Apex to have retain