### PR TITLE
Pick Them All pack: reduce Touched by Flame ignite and max HP loss by 1

### DIFF
--- a/src/main/java/thePackmaster/cards/pickthemallpack/TouchedByFlame.java
+++ b/src/main/java/thePackmaster/cards/pickthemallpack/TouchedByFlame.java
@@ -13,11 +13,11 @@ import thePackmaster.powers.shamanpack.IgnitePower;
 public class TouchedByFlame extends AbstractPickThemAllCard implements OnObtainCard {
     public static final String ID = SpireAnniversary5Mod.makeID("TouchedByFlame");
     private static final int COST = 1;
-    private static final int IGNITE = 9;
+    private static final int IGNITE = 8;
     private static final int UPGRADE_IGNITE = 1;
     private static final int WEAK_VULNERABLE = 1;
     private static final int UPGRADE_WEAK_VULNERABLE = 1;
-    private static final int PICKUP_MAX_HP_LOSS = 7;
+    private static final int PICKUP_MAX_HP_LOSS = 6;
 
     public TouchedByFlame() {
         super(ID, COST, CardType.SKILL, CardRarity.UNCOMMON, CardTarget.ENEMY);


### PR DESCRIPTION
Another tweak to this card, since I found it to still be quite strong. Reducing the ignite a bit more should tone it down. Reducing the max HP loss seems reasonable now that the card will be a bit less strong.