### PR TITLE
Magnetize pack polarity bug fix and Electron Flow discard effect speed up

### DIFF
--- a/src/main/java/thePackmaster/cards/magnetizepack/ElectronFlow.java
+++ b/src/main/java/thePackmaster/cards/magnetizepack/ElectronFlow.java
@@ -2,13 +2,19 @@ package thePackmaster.cards.magnetizepack;
 
 import basemod.helpers.CardModifierManager;
 import com.evacipated.cardcrawl.mod.stslib.actions.common.SelectCardsInHandAction;
-import com.megacrit.cardcrawl.actions.common.*;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.GameActionManager;
+import com.megacrit.cardcrawl.actions.common.MakeTempCardInHandAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import thePackmaster.cardmodifiers.magnetizepack.MagnetizedModifier;
 import thePackmaster.powers.magnetizepack.PolarityPower;
 import thePackmaster.util.Wiz;
+
+import java.util.ArrayList;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 
@@ -27,8 +33,22 @@ public class ElectronFlow extends AbstractMagnetizeCard {
 
             Wiz.applyToSelfTop(new PolarityPower(p, cards.size() * magicNumber));
 
-            for (AbstractCard c : cards)
-                addToTop(new DiscardSpecificCardAction(c));
+            ArrayList<AbstractCard> cards2 = new ArrayList<>(cards);
+            Wiz.att(new AbstractGameAction() {
+                @Override
+                public void update() {
+                    CardGroup group = AbstractDungeon.player.hand;
+                    for (AbstractCard c : cards2) {
+                        if (group.contains(c)) {
+                            group.moveToDiscardPile(c);
+                            GameActionManager.incrementDiscard(false);
+                            c.triggerOnManualDiscard();
+                        }
+                    }
+
+                    this.isDone = true;
+                }
+            });
         }));
 
         addToBot(new MakeTempCardInHandAction(cardsToPreview, 1));

--- a/src/main/java/thePackmaster/powers/magnetizepack/PolarityPower.java
+++ b/src/main/java/thePackmaster/powers/magnetizepack/PolarityPower.java
@@ -15,15 +15,27 @@ public class PolarityPower extends AbstractPackmasterPower implements CloneableP
     public static final String NAME = CardCrawlGame.languagePack.getPowerStrings(POWER_ID).NAME;
     public static final String[] DESCRIPTIONS = CardCrawlGame.languagePack.getPowerStrings(POWER_ID).DESCRIPTIONS;
 
+    public static final int STACKS_PER_ENERGY = 10;
+
     public PolarityPower(AbstractCreature owner, int amount) {
         super(POWER_ID, NAME, PowerType.BUFF, false, owner, amount);
     }
 
     public void stackPower(int stackAmount) {
         super.stackPower(stackAmount);
-        if (amount >= 10) {
-            addToTop(new GainEnergyAction(1));
-            amount -= 10;
+        this.convertPolarityToEnergy();
+    }
+
+    @Override
+    public void onInitialApplication() {
+        this.convertPolarityToEnergy();
+    }
+
+    private void convertPolarityToEnergy() {
+        if (amount >= STACKS_PER_ENERGY) {
+            int energy = amount / STACKS_PER_ENERGY;
+            addToTop(new GainEnergyAction(energy));
+            amount -= (energy * STACKS_PER_ENERGY);
             if (amount <= 0) {
                 addToTop(new RemoveSpecificPowerAction(owner, owner, this));
             }


### PR DESCRIPTION
* Magnetize pack: fix polarity behavior when you have 0 polarity and gain 10+ and when you gain enough at once to gain 2+ energy
* Magnetize pack: speed up Electron Flow discard effect by having it discard the cards all at once instead of one by one
