### PR TITLE
 Downfall pack: change Awaken Death to trigger before Fairy in a Bottle or Lizard Tail

### DIFF
--- a/src/main/java/thePackmaster/patches/downfallpack/PackmasterOnPlayerDeathPower.java
+++ b/src/main/java/thePackmaster/patches/downfallpack/PackmasterOnPlayerDeathPower.java
@@ -1,0 +1,16 @@
+package thePackmaster.patches.downfallpack;
+
+import com.megacrit.cardcrawl.cards.DamageInfo;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+
+// We've had to make our own version of StsLib's OnPlayerDeathPower because the StsLib
+// version triggers after base game on death relics such as Lizard Tail, which is never
+// what the player wants. While there's agreement that this is undesired and that it
+// would be best to change StsLib, StsLib doesn't seem to be getting updated much these
+// days, thus our implementation.
+public interface PackmasterOnPlayerDeathPower {
+    /**
+     * @return       Whether or not to kill the player (true = kill, false = live)
+     */
+    boolean onPlayerDeath(AbstractPlayer p, DamageInfo damageInfo);
+}

--- a/src/main/java/thePackmaster/patches/downfallpack/PackmasterOnPlayerDeathPowerPatch.java
+++ b/src/main/java/thePackmaster/patches/downfallpack/PackmasterOnPlayerDeathPowerPatch.java
@@ -1,0 +1,43 @@
+package thePackmaster.patches.downfallpack;
+
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.megacrit.cardcrawl.cards.DamageInfo;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+import javassist.CtBehavior;
+
+// This patch is based on OnPlayerDeathPatch from StsLib, but targets a different location so that it triggers before
+// Fairy in a Bottle and Lizard Tail. See the comment for the PackmasterOnPlayerDeathPower for details on why.
+// Note that this patch location assumes that this hook is being used for death prevention and that death prevention
+// powers count as healing (and should be blocked by having Mark of the Bloom). It's possible that there's some other
+// use case that would want to be treated differently, but that's not something we need to worry about for Packmaster.
+// See the StsLib patch at https://github.com/kiooeht/StSLib/blob/master/src/main/java/com/evacipated/cardcrawl/mod/stslib/patches/bothInterfaces/OnPlayerDeathPatch.java
+@SpirePatch(
+        clz= AbstractPlayer.class,
+        method="damage",
+        paramtypez={DamageInfo.class}
+)
+public class PackmasterOnPlayerDeathPowerPatch {
+    @SpireInsertPatch(
+            locator = Locator.class
+    )
+    public static SpireReturn<Void> Insert(AbstractPlayer __instance, DamageInfo info) {
+        for (AbstractPower power : __instance.powers) {
+            if (power instanceof PackmasterOnPlayerDeathPower) {
+                if (!((PackmasterOnPlayerDeathPower) power).onPlayerDeath(__instance, info)) {
+                    return SpireReturn.Return(null);
+                }
+            }
+        }
+
+        return SpireReturn.Continue();
+    }
+
+    private static class Locator extends SpireInsertLocator {
+        @Override
+        public int[] Locate(CtBehavior ctBehavior) throws Exception {
+            Matcher finalMatcher = new Matcher.MethodCallMatcher(AbstractPlayer.class, "hasPotion");
+            return LineFinder.findInOrder(ctBehavior, finalMatcher);
+        }
+    }
+}

--- a/src/main/java/thePackmaster/powers/downfallpack/AwakenDeathPower.java
+++ b/src/main/java/thePackmaster/powers/downfallpack/AwakenDeathPower.java
@@ -14,12 +14,13 @@ import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.powers.AbstractPower;
 import com.megacrit.cardcrawl.vfx.combat.IntenseZoomEffect;
+import thePackmaster.patches.downfallpack.PackmasterOnPlayerDeathPower;
 import thePackmaster.powers.AbstractPackmasterPower;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 
 
-public class AwakenDeathPower extends AbstractPackmasterPower implements OnPlayerDeathPower, CloneablePowerInterface {
+public class AwakenDeathPower extends AbstractPackmasterPower implements PackmasterOnPlayerDeathPower, CloneablePowerInterface {
     public static final String POWER_ID = makeID("AwakenDeathPower");
     public static final String NAME = CardCrawlGame.languagePack.getPowerStrings(POWER_ID).NAME;
     public static final String[] DESCRIPTIONS = CardCrawlGame.languagePack.getPowerStrings(POWER_ID).DESCRIPTIONS;

--- a/src/main/java/thePackmaster/powers/downfallpack/AwakenDeathPower.java
+++ b/src/main/java/thePackmaster/powers/downfallpack/AwakenDeathPower.java
@@ -27,7 +27,7 @@ public class AwakenDeathPower extends AbstractPackmasterPower implements Packmas
 
 
     public AwakenDeathPower(AbstractCreature owner, int amount) {
-        super(POWER_ID,NAME,PowerType.BUFF,true,owner,amount);
+        super(POWER_ID,NAME,PowerType.BUFF,false,owner,amount);
 
     }
 


### PR DESCRIPTION
Leaving this up for you to merge in case you want to wait longer or try again with getting this fix in StsLib.

You can also take a quick look over things and read the comments I wrote. The patch location I picked is easy to target, but it's inside a block of code that doesn't run if you have Mark of the Bloom. Essentially, it assumes on death powers are healing, which is accurate for the one and only power like this in the mod. Not something we need to worry about, but maybe Kio would care about other use cases for this interface and want to target a different location.