### PR TITLE
Implement Mari's Debuffs Pack Buffs and Bug Fixes

### DIFF
--- a/src/main/java/thePackmaster/cards/maridebuffpack/FacetiousFacade.java
+++ b/src/main/java/thePackmaster/cards/maridebuffpack/FacetiousFacade.java
@@ -18,7 +18,7 @@ public class FacetiousFacade extends AbstractMariDebuffCard {
 
     public FacetiousFacade() {
         super(ID, 1, CardType.ATTACK, CardRarity.UNCOMMON, CardTarget.ENEMY);
-        this.baseBlock = this.block = 16;
+        this.baseBlock = this.block = 14;
         this.baseDamage = this.damage = 24;
         this.baseMagicNumber = this.baseDamage - this.baseBlock;
         this.tags.add(CardTags.STRIKE);

--- a/src/main/java/thePackmaster/cards/maridebuffpack/Offguard.java
+++ b/src/main/java/thePackmaster/cards/maridebuffpack/Offguard.java
@@ -8,6 +8,7 @@ import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.powers.VulnerablePower;
+import thePackmaster.powers.maridebuffpack.HalfBlockPower;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 import static thePackmaster.util.Wiz.atb;
@@ -29,7 +30,9 @@ public class Offguard extends AbstractMariDebuffCard {
     @Override
     public void triggerWhenDrawn() {
         AbstractPlayer p = AbstractDungeon.player;
+        applyPowers();
         atb(new GainBlockAction(p, p, this.block));
+        atb(new ReducePowerAction(p, p, HalfBlockPower.POWER_ID, 1));
         atb(new ApplyPowerAction(p, p, new VulnerablePower(p, 1, false), 1));
     }
 

--- a/src/main/java/thePackmaster/cards/maridebuffpack/PentupAnger.java
+++ b/src/main/java/thePackmaster/cards/maridebuffpack/PentupAnger.java
@@ -38,7 +38,8 @@ public class PentupAnger extends AbstractMariDebuffCard {
 
     @Override
     public void upp() {
-        upgradeDamage(3);
+        upgradeDamage(2);
+        upgradeMagicNumber(1);
     }
 
 

--- a/src/main/java/thePackmaster/cards/maridebuffpack/RecurringTheme.java
+++ b/src/main/java/thePackmaster/cards/maridebuffpack/RecurringTheme.java
@@ -21,7 +21,7 @@ public class RecurringTheme extends AbstractMariDebuffCard {
     }
     public RecurringTheme(boolean upgraded) {
         super(ID, 0, CardType.ATTACK, CardRarity.UNCOMMON, CardTarget.ENEMY);
-        this.baseDamage = this.damage = 4;
+        this.baseDamage = this.damage = 5;
         this.exhaust = true;
         if(upgraded){
             this.upgrade();

--- a/src/main/java/thePackmaster/cards/maridebuffpack/TheFLYINGCAR.java
+++ b/src/main/java/thePackmaster/cards/maridebuffpack/TheFLYINGCAR.java
@@ -19,7 +19,7 @@ public class TheFLYINGCAR extends AbstractMariDebuffCard {
 
     public TheFLYINGCAR() {
         super(ID, 3, CardType.ATTACK, CardRarity.RARE, CardTarget.ENEMY);
-        this.baseDamage = this.damage = 25;
+        this.baseDamage = this.damage = 27;
         this.baseMagicNumber = this.magicNumber = 5;
    }
 

--- a/src/main/java/thePackmaster/cards/maridebuffpack/TheMANSION.java
+++ b/src/main/java/thePackmaster/cards/maridebuffpack/TheMANSION.java
@@ -15,7 +15,7 @@ public class TheMANSION extends AbstractMariDebuffCard {
 
     public TheMANSION() {
         super(ID, 2, CardType.SKILL, CardRarity.RARE, CardTarget.SELF);
-        this.baseBlock = this.block = 30;
+        this.baseBlock = this.block = 32;
    }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
@@ -25,7 +25,7 @@ public class TheMANSION extends AbstractMariDebuffCard {
 
     @Override
     public void upp() {
-        upgradeBlock(6);
+        upgradeBlock(8);
     }
 
 

--- a/src/main/java/thePackmaster/cards/maridebuffpack/ToughFront.java
+++ b/src/main/java/thePackmaster/cards/maridebuffpack/ToughFront.java
@@ -16,7 +16,7 @@ public class ToughFront extends AbstractMariDebuffCard {
 
     public ToughFront() {
         super(ID, 1, CardType.SKILL, CardRarity.COMMON, CardTarget.SELF);
-        this.baseBlock = this.block = 11;
+        this.baseBlock = this.block = 12;
    }
 
     public void use(AbstractPlayer p, AbstractMonster m) {


### PR DESCRIPTION
Card Changes:
Facetious Facade – 16(26) -> 14(24) Enemy Block
Pent-up Anger – 11(14) -> 11(13) Damage, 1(2) -> 1(3) Frail removal 
Recurring Theme – 4(6) -> 5(7) Damage
The FLYING CAR – 25 -> 27 Damage
The MANSION – 30(36) -> 32(40) Block
Tough Front – 11(14) -> 12(15) Block

Bug Fixes:
Fixed Off-Guard not properly reacting to HalfBlockPower 
Fixed Off-Guard+ not giving upgraded Block value on first draw