### PR TITLE
Graveyard pack: change Grey Bargain to give the card it returns purge

### DIFF
--- a/src/main/java/thePackmaster/cardmodifiers/cosmoscommand/PurgeModifier.java
+++ b/src/main/java/thePackmaster/cardmodifiers/cosmoscommand/PurgeModifier.java
@@ -1,6 +1,7 @@
 package thePackmaster.cardmodifiers.cosmoscommand;
 
 import basemod.abstracts.AbstractCardModifier;
+import com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.PurgeField;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.localization.UIStrings;
@@ -8,7 +9,7 @@ import com.megacrit.cardcrawl.localization.UIStrings;
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 
 public class PurgeModifier extends AbstractCardModifier {
-    public static String ID = makeID("PurgeCardModifier");
+    public static String ID = makeID("PurgeModifier");
     private static final UIStrings uiStrings = CardCrawlGame.languagePack.getUIString(makeID("PurgeModifier"));
     public static final String[] TEXT = uiStrings.TEXT;
 
@@ -19,15 +20,15 @@ public class PurgeModifier extends AbstractCardModifier {
     }
 
     public boolean shouldApply(AbstractCard card) {
-        return !card.purgeOnUse;
+        return !PurgeField.purge.get(card);
     }
 
     public void onInitialApplication(AbstractCard card) {
-        card.purgeOnUse = true;
+        PurgeField.purge.set(card, true);
     }
 
     public void onRemove(AbstractCard card) {
-        card.purgeOnUse = false;
+        PurgeField.purge.set(card, false);
     }
 
     public AbstractCardModifier makeCopy() {

--- a/src/main/java/thePackmaster/cards/graveyardpack/AncientSpear.java
+++ b/src/main/java/thePackmaster/cards/graveyardpack/AncientSpear.java
@@ -26,7 +26,7 @@ public class AncientSpear
   public AncientSpear() {
 	super(ID, COST, TYPE, RARITY, TARGET);
 	
-    this.baseDamage = 20;
+    this.baseDamage = 22;
     this.damage=this.baseDamage;
     
     this.exhaust = true;

--- a/src/main/java/thePackmaster/cards/graveyardpack/FleshLikeOak.java
+++ b/src/main/java/thePackmaster/cards/graveyardpack/FleshLikeOak.java
@@ -30,8 +30,8 @@ public class FleshLikeOak extends AbstractGraveyardCard
 		super(ID, COST, TYPE, RARITY, TARGET);
 		
 		this.exhaust = true;
-		this.magicNumber = this.baseMagicNumber = 1;
-		this.block = this.baseBlock = 12;
+		this.magicNumber = this.baseMagicNumber = 2;
+		this.block = this.baseBlock = 13;
 	}
 
 	public void use(AbstractPlayer p, AbstractMonster m) {

--- a/src/main/java/thePackmaster/cards/graveyardpack/GreyBargain.java
+++ b/src/main/java/thePackmaster/cards/graveyardpack/GreyBargain.java
@@ -1,5 +1,6 @@
 package thePackmaster.cards.graveyardpack;
 
+import basemod.helpers.CardModifierManager;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
@@ -15,6 +16,8 @@ import com.megacrit.cardcrawl.actions.common.DrawCardAction;
 import com.megacrit.cardcrawl.actions.common.ExhaustAction;
 import com.megacrit.cardcrawl.actions.common.ShuffleAction;
 import com.evacipated.cardcrawl.mod.stslib.actions.common.MoveCardsAction;
+import thePackmaster.cardmodifiers.cosmoscommand.PurgeModifier;
+
 import java.util.function.Predicate;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
@@ -38,7 +41,7 @@ public class GreyBargain
   public void use(AbstractPlayer p, AbstractMonster m) {
 	  if(p.hand.size()>0) {
 		  Predicate<AbstractCard> classy = card -> !(card.color.equals(AbstractCard.CardColor.COLORLESS) || card.color.equals(AbstractCard.CardColor.CURSE) || card.type.equals(AbstractCard.CardType.CURSE) || card.type.equals(AbstractCard.CardType.STATUS));
-		  AbstractDungeon.actionManager.addToBottom(new MoveCardsAction(p.drawPile, p.exhaustPile, classy, (c) -> c.forEach(card -> { p.drawPile.removeCard(card); p.drawPile.addToRandomSpot(card); })));
+		  AbstractDungeon.actionManager.addToBottom(new MoveCardsAction(p.drawPile, p.exhaustPile, classy, (c) -> c.forEach(card -> { CardModifierManager.addModifier(card, new PurgeModifier()); p.drawPile.removeCard(card); p.drawPile.addToRandomSpot(card); })));
 		  AbstractDungeon.actionManager.addToBottom(new ExhaustAction(p,p,1,false));
 	  }
 	  if(this.upgraded) {

--- a/src/main/java/thePackmaster/cards/graveyardpack/Tombstone.java
+++ b/src/main/java/thePackmaster/cards/graveyardpack/Tombstone.java
@@ -33,7 +33,7 @@ public class Tombstone
     this.baseDamage = 30;
     this.damage=this.baseDamage;
     
-	this.block = this.baseBlock = 5;
+	this.block = this.baseBlock = 10;
     
     this.exhaust = true;
   }

--- a/src/main/resources/anniv5Resources/localization/eng/graveyardpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/graveyardpack/Cardstrings.json
@@ -1,8 +1,8 @@
 {
   "${ModID}:GreyBargain": {
     "NAME": "Grey Bargain",
-    "DESCRIPTION": "Return a ${ModID}:Buried card to your draw pile by Exhausting a card in your hand.",
-    "UPGRADE_DESCRIPTION": "Return a ${ModID}:Buried card to your draw pile by Exhausting a card in your hand. NL Draw 1 card.",
+    "DESCRIPTION": "Return a ${ModID}:Buried card to your draw pile by *Exhausting a card in your hand. NL Give it stslib:Purge.",
+    "UPGRADE_DESCRIPTION": "Return a ${ModID}:Buried card to your draw pile by *Exhausting a card in your hand. NL Give it stslib:Purge. NL Draw 1 card.",
     "EXTENDED_DESCRIPTION": ["I need a card to Exhaust."]
   },
     "${ModID}:ExtraLimbs": {


### PR DESCRIPTION
Leaving this one up for you to merge in case you want to look over it or discuss further.

The PurgeModifier class that I repurposed doesn't seem to be used by anything. I assume it was used at some point, but the card that used it got reworked. Regardless, it was convenient for me since it meant the text was already there, so I just swapped it over to using the new PurgeField.