### PR TITLE
card creation trigger

### DIFF
--- a/src/main/java/thePackmaster/cards/needleworkpack/Patchwork.java
+++ b/src/main/java/thePackmaster/cards/needleworkpack/Patchwork.java
@@ -1,8 +1,12 @@
 package thePackmaster.cards.needleworkpack;
 
+import com.evacipated.cardcrawl.mod.stslib.StSLib;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.powers.watcher.MasterRealityPower;
 import thePackmaster.actions.needlework.StitchAction;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
@@ -26,6 +30,17 @@ public class Patchwork extends AbstractNeedleworkCard {
         cpy.current_x = cpy.target_x = current_x;
         cpy.current_y = cpy.target_y = current_y;
 
+        addToBot(new AbstractGameAction() {
+            @Override
+            public void update() {
+                isDone = true;
+
+                if (AbstractDungeon.player.hasPower(MasterRealityPower.POWER_ID)) {
+                    cpy.upgrade();
+                }
+                StSLib.onCreateCard(cpy);
+            }
+        });
         addToBot(new StitchAction(cpy));
     }
 

--- a/src/main/java/thePackmaster/powers/needlework/ReadingPower.java
+++ b/src/main/java/thePackmaster/powers/needlework/ReadingPower.java
@@ -40,15 +40,22 @@ public class ReadingPower extends AbstractPackmasterPower implements CloneablePo
                     SuperUpgradeAction.forceUpgrade(toStitch, false);
                 }
 
-                if (AbstractDungeon.player.hasPower(MasterRealityPower.POWER_ID)) {
-                    toStitch.upgrade(); //Will only do anything if you would make an unupgraded one
-                }
-                StSLib.onCreateCard(toStitch);
-
                 toStitch.drawScale = toStitch.targetDrawScale = 0.1f;
                 toStitch.current_x = toStitch.target_x = Settings.WIDTH / 2f;
                 toStitch.current_y = toStitch.target_y = Settings.HEIGHT * 2;
                 addToTop(new StitchAction(toStitch));
+
+                addToTop(new AbstractGameAction() {
+                    @Override
+                    public void update() {
+                        isDone = true;
+
+                        if (AbstractDungeon.player.hasPower(MasterRealityPower.POWER_ID)) {
+                            toStitch.upgrade(); //Will only do anything if you would make an unupgraded one
+                        }
+                        StSLib.onCreateCard(toStitch);
+                    }
+                });
             }
         });
     }

--- a/src/main/java/thePackmaster/powers/needlework/ReadingPower.java
+++ b/src/main/java/thePackmaster/powers/needlework/ReadingPower.java
@@ -1,12 +1,15 @@
 package thePackmaster.powers.needlework;
 
 import basemod.interfaces.CloneablePowerInterface;
+import com.evacipated.cardcrawl.mod.stslib.StSLib;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.FontHelper;
 import com.megacrit.cardcrawl.powers.AbstractPower;
+import com.megacrit.cardcrawl.powers.watcher.MasterRealityPower;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.actions.needlework.StitchAction;
 import thePackmaster.actions.upgradespack.SuperUpgradeAction;
@@ -36,6 +39,11 @@ public class ReadingPower extends AbstractPackmasterPower implements CloneablePo
                 for (int upg = 1; upg < upgAmount; ++upg) {
                     SuperUpgradeAction.forceUpgrade(toStitch, false);
                 }
+
+                if (AbstractDungeon.player.hasPower(MasterRealityPower.POWER_ID)) {
+                    toStitch.upgrade(); //Will only do anything if you would make an unupgraded one
+                }
+                StSLib.onCreateCard(toStitch);
 
                 toStitch.drawScale = toStitch.targetDrawScale = 0.1f;
                 toStitch.current_x = toStitch.target_x = Settings.WIDTH / 2f;


### PR DESCRIPTION
actions are used to mimick timing of card creation patch occurring in the update of actions