### PR TITLE
Balance doppel pack: nerf some cards

### DIFF
--- a/src/main/java/thePackmaster/cards/doppelpack/Concatenation.java
+++ b/src/main/java/thePackmaster/cards/doppelpack/Concatenation.java
@@ -68,7 +68,6 @@ public class Concatenation extends AbstractDoppelCard {
         this.addToBot(
                 new DamageAction(m, new DamageInfo(p, damage, damageTypeForTurn),
                     AbstractGameAction.AttackEffect.NONE));
-        this.addToBot(new DrawCardAction(1));
         this.addToBot(new WaitAction(0.1f));
         this.addToBot(new AbstractGameAction() {
             @Override

--- a/src/main/java/thePackmaster/cards/doppelpack/Resistance.java
+++ b/src/main/java/thePackmaster/cards/doppelpack/Resistance.java
@@ -53,7 +53,6 @@ public class Resistance extends AbstractDoppelCard {
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
         this.addToBot(new GainBlockAction(p, p, block));
-        this.addToBot(new DrawCardAction(1));
         this.addToBot(new WaitAction(0.1f));
         this.addToBot(new AbstractGameAction() {
             @Override

--- a/src/main/java/thePackmaster/cards/doppelpack/Summon.java
+++ b/src/main/java/thePackmaster/cards/doppelpack/Summon.java
@@ -12,7 +12,7 @@ public class Summon extends AbstractDoppelCard {
 
     public Summon() {
         super(ID, 1, AbstractCard.CardType.SKILL, CardRarity.COMMON, AbstractCard.CardTarget.SELF);
-        magicNumber = baseMagicNumber = 2;
+        magicNumber = baseMagicNumber = 1;
         previewDoppel = true;
     }
 

--- a/src/main/java/thePackmaster/cards/doppelpack/Tides.java
+++ b/src/main/java/thePackmaster/cards/doppelpack/Tides.java
@@ -4,7 +4,9 @@ import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.DamageAction;
 import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.orbs.EmptyOrbSlot;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.actions.doppelpack.SummonAction;
 import thePackmaster.orbs.doppelpack.AbstractDoppel;
@@ -14,8 +16,8 @@ public class Tides extends AbstractDoppelCard {
 
     public Tides() {
         super(ID, 2, CardType.ATTACK, CardRarity.UNCOMMON, CardTarget.ENEMY);
-        baseDamage = 6;
-        previewDoppel = true;
+        baseDamage = 5;
+        baseMagicNumber = magicNumber = 1;
     }
 
     @Override
@@ -24,13 +26,33 @@ public class Tides extends AbstractDoppelCard {
     }
 
     @Override
+    public void applyPowers() {
+        int oldBaseDamage = baseDamage;
+        baseDamage += baseMagicNumber * getOrbCount();
+        super.applyPowers();
+        baseDamage = oldBaseDamage;
+        isDamageModified = damage != baseDamage;
+    }
+
+    @Override
+    public void calculateCardDamage(AbstractMonster mo) {
+        int oldBaseDamage = baseDamage;
+        baseDamage += baseMagicNumber * getOrbCount();
+        super.calculateCardDamage(mo);
+        baseDamage = oldBaseDamage;
+        isDamageModified = damage != baseDamage;
+    }
+
+    @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
-        int count = (int) p.orbs.stream().filter(o -> o instanceof AbstractDoppel).count();
-        for (int i = -2; i < count; i++) {
+        for (int i = 0; i < 3; i++) {
             addToBot(
                     new DamageAction(m, new DamageInfo(p, damage, damageTypeForTurn),
                             AbstractGameAction.AttackEffect.BLUNT_LIGHT));
         }
-        addToBot(new SummonAction());
+    }
+
+    private static int getOrbCount() {
+        return (int) AbstractDungeon.player.orbs.stream().filter(o -> !(o instanceof EmptyOrbSlot)).count();
     }
 }

--- a/src/main/java/thePackmaster/cards/doppelpack/Vortex.java
+++ b/src/main/java/thePackmaster/cards/doppelpack/Vortex.java
@@ -25,7 +25,7 @@ public class Vortex extends AbstractDoppelCard {
 
     public Vortex() {
         super(ID, 1, CardType.ATTACK, CardRarity.UNCOMMON, CardTarget.ENEMY);
-        baseDamage = 9;
+        baseDamage = 8;
     }
 
     @Override

--- a/src/main/java/thePackmaster/orbs/doppelpack/AbstractDoppel.java
+++ b/src/main/java/thePackmaster/orbs/doppelpack/AbstractDoppel.java
@@ -83,8 +83,8 @@ public abstract class AbstractDoppel extends AbstractOrb {
         super.applyFocus();
         AbstractPower focusPower = AbstractDungeon.player.getPower(FocusPower.POWER_ID);
         int numFocus = (focusPower != null ? focusPower.amount : 0);
-        AbstractPower wormHolePower = AbstractDungeon.player.getPower(WormHolePower.ID);
-        int numWormHole = (wormHolePower != null ? wormHolePower.amount : 0);
+        WormHolePower wormHolePower = (WormHolePower) AbstractDungeon.player.getPower(WormHolePower.ID);
+        int numWormHole = (wormHolePower != null ? wormHolePower.getEffectAmount() : 0);
         applyPowers(numFocus, numWormHole);
     }
 

--- a/src/main/java/thePackmaster/packs/DoppelPack.java
+++ b/src/main/java/thePackmaster/packs/DoppelPack.java
@@ -27,7 +27,7 @@ public class DoppelPack extends AbstractCardPack {
     public static final HashMap<String, CardProperty> cachedCardProperties = new HashMap<>();
 
     public DoppelPack() {
-        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 3, 5, 4, 1, PackSummary.Tags.Orbs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 3, 5, 4, 1, PackSummary.Tags.Orbs));
 
         if (frameBuffer == null) {
             frameBuffer = new FrameBuffer(Pixmap.Format.RGBA8888, Settings.WIDTH, Settings.HEIGHT, false, false);

--- a/src/main/java/thePackmaster/powers/doppelpack/WormHolePower.java
+++ b/src/main/java/thePackmaster/powers/doppelpack/WormHolePower.java
@@ -15,7 +15,7 @@ public class WormHolePower extends AbstractPackmasterPower {
     private static final String[] DESCRIPTIONS = STRINGS.DESCRIPTIONS;
 
     public WormHolePower(AbstractCreature owner, int amount) {
-        super(ID, STRINGS.NAME, PowerType.BUFF, false, owner, amount);
+        super(ID, STRINGS.NAME, PowerType.BUFF, false, owner, -1);
     }
 
     @Override
@@ -35,6 +35,10 @@ public class WormHolePower extends AbstractPackmasterPower {
 
     @Override
     public void updateDescription() {
-        this.description = String.format(DESCRIPTIONS[0], amount);
+        this.description = String.format(DESCRIPTIONS[0], 1);
+    }
+
+    public int getEffectAmount() {
+        return 1;
     }
 }

--- a/src/main/resources/anniv5Resources/localization/eng/doppelpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/doppelpack/Cardstrings.json
@@ -1,7 +1,7 @@
 {
   "${ModID}:Summon": {
     "NAME": "Summon",
-    "DESCRIPTION": "Draw !M! cards. NL Channel 1 ${ModID}:Doppel."
+    "DESCRIPTION": "Draw {@@}!M! card{!M!|0,>1=s}. NL Channel 1 ${ModID}:Doppel."
   },
   "${ModID}:Arrive": {
     "NAME": "Arrive",
@@ -10,7 +10,7 @@
   },
   "${ModID}:Concatenation": {
     "NAME": "Concatenation",
-    "DESCRIPTION": "Deal !D! damage. NL Draw 1 card. NL Channel 1 ${ModID}:Doppel with the leftmost Attack in your hand."
+    "DESCRIPTION": "Deal !D! damage. NL Channel 1 ${ModID}:Doppel with the leftmost Attack in your hand."
   },
   "${ModID}:EmergencyContact": {
     "NAME": "Emergency Contact",
@@ -30,11 +30,11 @@
   },
   "${ModID}:Resistance": {
     "NAME": "Resistance",
-    "DESCRIPTION": "Gain !B! Block. NL Draw 1 card. NL Channel 1 ${ModID}:Doppel with the leftmost Skill in your hand."
+    "DESCRIPTION": "Gain !B! Block. NL Channel 1 ${ModID}:Doppel with the leftmost Skill in your hand."
   },
   "${ModID}:Tides": {
     "NAME": "Tides",
-    "DESCRIPTION": "Deal !D! damage twice. NL Deal !D! damage for each ${ModID}:Doppel. NL Channel 1 ${ModID}:Doppel."
+    "DESCRIPTION": "Deal !D! damage 3 times. NL Deal !M! additional damage for each Channeled Orb."
   },
   "${ModID}:Turbulence": {
     "NAME": "Turbulence",

--- a/src/main/resources/anniv5Resources/localization/zhs/doppelpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/zhs/doppelpack/Cardstrings.json
@@ -10,7 +10,7 @@
   },
   "${ModID}:Concatenation": {
     "NAME": "并列",
-    "DESCRIPTION": "造成 !D! 点伤害。 NL 抽1张牌。 NL 使用手中最左侧的 攻击牌 生成 1个 ${ModID}:分身 。"
+    "DESCRIPTION": "造成 !D! 点伤害。 NL 使用手中最左侧的 攻击牌 生成 1个 ${ModID}:分身 。"
   },
   "${ModID}:EmergencyContact": {
     "NAME": "紧急联络",
@@ -30,11 +30,11 @@
   },
   "${ModID}:Resistance": {
     "NAME": "抵抗",
-    "DESCRIPTION": "获得 !B! 点 格挡 。 NL 抽1张牌。 NL 使用手中最左侧的 技能牌 生成 1个 ${ModID}:分身 。"
+    "DESCRIPTION": "获得 !B! 点 格挡 。 NL 使用手中最左侧的 技能牌 生成 1个 ${ModID}:分身 。"
   },
   "${ModID}:Tides": {
     "NAME": "浪潮",
-    "DESCRIPTION": "造成 !D! 点伤害 2 次。 NL 每有一个 ${ModID}:分身 ，再造成 !D! 点伤害。 NL 生成 1个 ${ModID}:分身 。"
+    "DESCRIPTION": "造成 !D! 点伤害 3 次。 NL 你每有一个充能球，伤害+ !M! 。"
   },
   "${ModID}:Turbulence": {
     "NAME": "湍流",


### PR DESCRIPTION
Concatenation: Remove "Draw 1 card".
Resistance: Remove "Draw 1 card".
Summon: Reduce card draw: 2(3) -> 1(2).
Tides: Remove "Summon 1 Doppel". Damage value change: 6(8) times 2+N -> 5(7)+N times 3.
Vortex: Reduce damage: 9(12) -> 8(11).
Worm Hole: Doesn't stack.
